### PR TITLE
More aggressively map unusual characters to -

### DIFF
--- a/git-pivotal.js
+++ b/git-pivotal.js
@@ -236,7 +236,7 @@ function chooseStory(stories) {
 function makeBranchNameForStory(story) {
   dlog('makeBranchNameForStory with story:', story);
   var branchType = story.story_type || branch_type;
-  var branch = branchType + '/' + story.name.replace(/\s+/g, '-', 'g') + '_' + story.id;
+  var branch = branchType + '/' + story.name.replace(/\W+/g, '-', 'g') + '_' + story.id;
   return branch;
 }
 


### PR DESCRIPTION
Previously we only mapped runs of spaces to -.
Now we map runs of non-word characters to -.
This should guarantee that generated branch names are always valid.